### PR TITLE
タスク編集機能と登録日時表示機能の実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,9 @@
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git fetch:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(git pull:*)",
+      "Bash(git rebase:*)"
     ],
     "deny": []
   }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
     implementation("androidx.compose.runtime:runtime-livedata")
     implementation("androidx.compose.animation:animation:1.5.8")
     
+    // Navigation Compose
+    implementation("androidx.navigation:navigation-compose:2.7.6")
+    
     // Compose Tooling (for debug)
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/java/com/example/todo/MainActivity.kt
+++ b/app/src/main/java/com/example/todo/MainActivity.kt
@@ -9,6 +9,7 @@ import android.widget.Button
 import android.widget.EditText
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.animation.doOnEnd
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -71,6 +72,9 @@ class MainActivity : AppCompatActivity() {
             },
             onTaskDelete = { taskId ->
                 taskViewModel.deleteTask(taskId)
+            },
+            onTaskEdit = { taskId, currentTitle ->
+                showEditTaskDialog(taskId, currentTitle)
             }
         )
         
@@ -118,5 +122,26 @@ class MainActivity : AppCompatActivity() {
         taskViewModel.tasks.observe(this) { tasks ->
             taskAdapter.submitList(tasks)
         }
+    }
+    
+    private fun showEditTaskDialog(taskId: Int, currentTitle: String) {
+        val editText = EditText(this).apply {
+            setText(currentTitle)
+            selectAll()
+        }
+        
+        AlertDialog.Builder(this)
+            .setTitle("タスクを編集")
+            .setView(editText)
+            .setPositiveButton("保存") { _, _ ->
+                val newTitle = editText.text.toString()
+                if (newTitle.isNotBlank()) {
+                    taskViewModel.updateTask(taskId, newTitle)
+                }
+            }
+            .setNegativeButton("キャンセル", null)
+            .show()
+        
+        editText.requestFocus()
     }
 }

--- a/app/src/main/java/com/example/todo/MainComposeActivity.kt
+++ b/app/src/main/java/com/example/todo/MainComposeActivity.kt
@@ -110,6 +110,9 @@ fun TodoApp(viewModel: TaskViewModel, navController: NavHostController) {
                     onDeleteTask = {
                         viewModel.deleteTask(task.id)
                         navController.popBackStack()
+                    },
+                    onEditTask = { newTitle ->
+                        viewModel.updateTask(task.id, newTitle)
                     }
                 )
             }

--- a/app/src/main/java/com/example/todo/Task.kt
+++ b/app/src/main/java/com/example/todo/Task.kt
@@ -1,7 +1,10 @@
 package com.example.todo
 
+import java.util.Date
+
 data class Task(
     val id: Int,
     val title: String,
-    val isDone: Boolean
+    val isDone: Boolean,
+    val createdAt: Date
 )

--- a/app/src/main/java/com/example/todo/TaskAdapter.kt
+++ b/app/src/main/java/com/example/todo/TaskAdapter.kt
@@ -16,10 +16,13 @@ import androidx.core.animation.doOnEnd
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class TaskAdapter(
     private val onTaskToggle: (Int) -> Unit,
-    private val onTaskDelete: (Int) -> Unit
+    private val onTaskDelete: (Int) -> Unit,
+    private val onTaskEdit: (Int, String) -> Unit
 ) : ListAdapter<Task, TaskAdapter.TaskViewHolder>(TaskDiffCallback()) {
     
     private var shouldAnimateNewItem = false
@@ -54,11 +57,15 @@ class TaskAdapter(
     inner class TaskViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val checkBoxDone: CheckBox = itemView.findViewById(R.id.checkBoxDone)
         private val textViewTitle: TextView = itemView.findViewById(R.id.textViewTitle)
+        private val textViewCreatedAt: TextView = itemView.findViewById(R.id.textViewCreatedAt)
         private val buttonDelete: ImageButton = itemView.findViewById(R.id.buttonDelete)
+        
+        private val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault())
 
         fun bind(task: Task) {
             textViewTitle.text = task.title
             checkBoxDone.isChecked = task.isDone
+            textViewCreatedAt.text = dateFormat.format(task.createdAt)
             
             // Apply strikethrough for completed tasks
             if (task.isDone) {
@@ -78,6 +85,10 @@ class TaskAdapter(
                 animateItemDelete(itemView) {
                     onTaskDelete(task.id)
                 }
+            }
+            
+            textViewTitle.setOnClickListener {
+                onTaskEdit(task.id, task.title)
             }
         }
     }

--- a/app/src/main/java/com/example/todo/TaskDatabase.kt
+++ b/app/src/main/java/com/example/todo/TaskDatabase.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [TaskEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class TaskDatabase : RoomDatabase() {
@@ -17,13 +19,19 @@ abstract class TaskDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: TaskDatabase? = null
 
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE tasks ADD COLUMN createdAt INTEGER NOT NULL DEFAULT ${System.currentTimeMillis()}")
+            }
+        }
+
         fun getDatabase(context: Context): TaskDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     TaskDatabase::class.java,
                     "task_database"
-                ).build()
+                ).addMigrations(MIGRATION_1_2).build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/example/todo/TaskEntity.kt
+++ b/app/src/main/java/com/example/todo/TaskEntity.kt
@@ -2,20 +2,38 @@ package com.example.todo
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.TypeConverter
+import androidx.room.TypeConverters
+import java.util.Date
+
+class Converters {
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+}
 
 @Entity(tableName = "tasks")
+@TypeConverters(Converters::class)
 data class TaskEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
     val title: String,
-    val isDone: Boolean
+    val isDone: Boolean,
+    val createdAt: Date = Date()
 )
 
 fun TaskEntity.toTask(): Task {
     return Task(
         id = this.id,
         title = this.title,
-        isDone = this.isDone
+        isDone = this.isDone,
+        createdAt = this.createdAt
     )
 }
 
@@ -23,6 +41,7 @@ fun Task.toTaskEntity(): TaskEntity {
     return TaskEntity(
         id = this.id,
         title = this.title,
-        isDone = this.isDone
+        isDone = this.isDone,
+        createdAt = this.createdAt
     )
 }

--- a/app/src/main/java/com/example/todo/TaskViewModel.kt
+++ b/app/src/main/java/com/example/todo/TaskViewModel.kt
@@ -22,7 +22,8 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
                 val newTask = Task(
                     id = 0, // Room will auto-generate the ID
                     title = title.trim(),
-                    isDone = false
+                    isDone = false,
+                    createdAt = java.util.Date()
                 )
                 repository.insert(newTask)
             }
@@ -42,6 +43,18 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     fun deleteTask(taskId: Int) {
         viewModelScope.launch {
             repository.delete(taskId)
+        }
+    }
+    
+    fun updateTask(taskId: Int, newTitle: String) {
+        if (newTitle.isNotBlank()) {
+            viewModelScope.launch {
+                val task = repository.getTaskById(taskId)
+                task?.let {
+                    val updatedTask = it.copy(title = newTitle.trim())
+                    repository.update(updatedTask)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/todo/TodoDetailScreen.kt
+++ b/app/src/main/java/com/example/todo/TodoDetailScreen.kt
@@ -1,0 +1,227 @@
+package com.example.todo
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodoDetailScreen(
+    task: Task,
+    onBackClick: () -> Unit,
+    onToggleTask: () -> Unit,
+    onDeleteTask: () -> Unit
+) {
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("タスク詳細") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "戻る"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showDeleteDialog = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "削除",
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                    actionIconContentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            // タスクステータスカード
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    // ステータスバッジ
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (task.isDone) Icons.Default.Check else Icons.Default.Edit,
+                            contentDescription = if (task.isDone) "完了" else "未完了",
+                            tint = if (task.isDone) 
+                                MaterialTheme.colorScheme.primary 
+                            else 
+                                MaterialTheme.colorScheme.outline
+                        )
+                        Text(
+                            text = if (task.isDone) "完了済み" else "未完了",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Medium,
+                            color = if (task.isDone) 
+                                MaterialTheme.colorScheme.primary 
+                            else 
+                                MaterialTheme.colorScheme.outline
+                        )
+                    }
+                    
+                    // タスクタイトル
+                    Text(
+                        text = task.title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        textDecoration = if (task.isDone) TextDecoration.LineThrough else null,
+                        color = if (task.isDone)
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                        else
+                            MaterialTheme.colorScheme.onSurface
+                    )
+                    
+                    // タスクID
+                    Text(
+                        text = "ID: ${task.id}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline
+                    )
+                }
+            }
+            
+            // アクションボタン
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = "アクション",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Medium
+                    )
+                    
+                    Button(
+                        onClick = onToggleTask,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (task.isDone)
+                                MaterialTheme.colorScheme.outline
+                            else
+                                MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Icon(
+                            imageVector = if (task.isDone) Icons.Default.Edit else Icons.Default.Check,
+                            contentDescription = if (task.isDone) "未完了にする" else "完了にする"
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (task.isDone) "未完了にする" else "完了にする"
+                        )
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.weight(1f))
+            
+            // タスク詳細情報
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                shape = RoundedCornerShape(8.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "詳細情報",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = "作成日時:",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "詳細機能は今後実装予定",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+    
+    // 削除確認ダイアログ
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("タスクを削除") },
+            text = { Text("「${task.title}」を削除しますか？この操作は元に戻せません。") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showDeleteDialog = false
+                        onDeleteTask()
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text("削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/todo/TodoDetailScreen.kt
+++ b/app/src/main/java/com/example/todo/TodoDetailScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,9 +24,12 @@ fun TodoDetailScreen(
     task: Task,
     onBackClick: () -> Unit,
     onToggleTask: () -> Unit,
-    onDeleteTask: () -> Unit
+    onDeleteTask: () -> Unit,
+    onEditTask: (String) -> Unit = {}
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var showEditDialog by remember { mutableStateOf(false) }
+    val dateFormat = SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.getDefault())
     
     Scaffold(
         topBar = {
@@ -39,6 +44,13 @@ fun TodoDetailScreen(
                     }
                 },
                 actions = {
+                    IconButton(onClick = { showEditDialog = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "編集",
+                            tint = MaterialTheme.colorScheme.onPrimary
+                        )
+                    }
                     IconButton(onClick = { showDeleteDialog = true }) {
                         Icon(
                             imageVector = Icons.Default.Delete,
@@ -188,7 +200,7 @@ fun TodoDetailScreen(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Text(
-                            text = "詳細機能は今後実装予定",
+                            text = dateFormat.format(task.createdAt),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -219,6 +231,41 @@ fun TodoDetailScreen(
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+    
+    // 編集ダイアログ
+    if (showEditDialog) {
+        var editText by remember { mutableStateOf(task.title) }
+        
+        AlertDialog(
+            onDismissRequest = { showEditDialog = false },
+            title = { Text("タスクを編集") },
+            text = {
+                OutlinedTextField(
+                    value = editText,
+                    onValueChange = { editText = it },
+                    label = { Text("タスクタイトル") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        if (editText.isNotBlank()) {
+                            onEditTask(editText)
+                            showEditDialog = false
+                        }
+                    }
+                ) {
+                    Text("保存")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEditDialog = false }) {
                     Text("キャンセル")
                 }
             }

--- a/app/src/main/res/layout/item_task.xml
+++ b/app/src/main/res/layout/item_task.xml
@@ -20,15 +20,30 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical" />
 
-    <TextView
-        android:id="@+id/textViewTitle"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:layout_marginStart="12dp"
         android:layout_gravity="center_vertical"
-        android:textSize="16sp"
-        android:textColor="?android:attr/textColorPrimary" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/textViewTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textColor="?android:attr/textColorPrimary" />
+
+        <TextView
+            android:id="@+id/textViewCreatedAt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginTop="2dp" />
+
+    </LinearLayout>
 
     <ImageButton
         android:id="@+id/buttonDelete"

--- a/backup/xml-layouts/activity_main.xml
+++ b/backup/xml-layouts/activity_main.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            app:title="@string/app_name"
+            app:titleTextAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Title" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <EditText
+            android:id="@+id/editTextTask"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:hint="新しいタスクを入力"
+            android:inputType="text"
+            android:imeOptions="actionDone"
+            app:layout_constraintEnd_toStartOf="@+id/buttonAdd"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/buttonAdd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:text="追加"
+            app:layout_constraintBottom_toBottomOf="@+id/editTextTask"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/editTextTask" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewTasks"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="8dp"
+            android:clipToPadding="false"
+            android:paddingTop="8dp"
+            android:paddingBottom="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/editTextTask"
+            tools:listitem="@layout/item_task" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/backup/xml-layouts/item_task.xml
+++ b/backup/xml-layouts/item_task.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp"
+    android:foreground="?android:attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+    <CheckBox
+        android:id="@+id/checkBoxDone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical" />
+
+    <TextView
+        android:id="@+id/textViewTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="12dp"
+        android:layout_gravity="center_vertical"
+        android:textSize="16sp"
+        android:textColor="?android:attr/textColorPrimary" />
+
+    <ImageButton
+        android:id="@+id/buttonDelete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="8dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@android:drawable/ic_menu_delete"
+        android:contentDescription="Delete task"
+        android:padding="8dp" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## 概要
TODO詳細画面でのタスク編集機能と登録日時表示機能を実装しました。

## 変更内容

### ✨ 新機能
- **タスク編集機能**: タスクタイトルをタップまたは詳細画面で編集可能
- **登録日時表示**: 各タスクの作成日時を記録・表示
- **詳細画面の機能強化**: 編集ダイアログと登録日時表示

### 🔧 技術的な実装
- Taskデータクラスに`createdAt`フィールドを追加
- データベースマイグレーション（v1→v2）で既存データに対応
- TaskViewModelに`updateTask`メソッドを追加
- 編集ダイアログ（AlertDialog + OutlinedTextField）を実装
- 日時フォーマット（yyyy/MM/dd HH:mm）での表示

### 🎨 UI/UX改善
- メイン画面でタスクタイトルタップによる編集
- 詳細画面での編集アイコンとダイアログ
- タスクアイテムに登録日時を表示
- 保存・キャンセル機能付きの編集フォーム

## テスト計画
- [x] 新規タスク作成時の登録日時記録
- [x] タスクタイトルタップでの編集ダイアログ表示
- [x] 詳細画面での編集機能
- [x] 登録日時の正確な表示
- [x] データベースマイグレーションの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)